### PR TITLE
Better notification script

### DIFF
--- a/notification.sh
+++ b/notification.sh
@@ -7,24 +7,21 @@ ARG1=`echo $ARGS | awk '{print $1}'`
 
 call_curl () {
 	DATA=`echo "s=$1&action=$2&b=%234" | sed -e s/:/%3A/`
-	curl $HAPROXY --data "$DATA"
+	curl --silent -o /dev/null $HAPROXY --data "$DATA"
 	echo curl $HAPROXY --data "$DATA"
 }
 
 
-[ "$CMD" = "+sdown" ] && [ "$ARG1" = "master" ] && \
+[ "$CMD" = "+odown" ] && [ "$ARG1" = "master" ] && \
 	call_curl `echo $ARGS | awk '{print $2 ":" $3 ":" $4}'` 'disable'
 
 [ "$CMD" = "+sdown" ] && [ "$ARG1" = "slave" ] && \
 	call_curl `echo $ARGS | awk '{print $6 ":" $3 ":" $4}'` 'disable'
 
-[ "$CMD" = "+convert-to-slave" ] && \
-	call_curl `echo $ARGS | awk '{print $6 ":" $3 ":" $4}'` 'enable'
-
 [ "$CMD" = "+switch-master" ] && \
 	call_curl `echo $ARGS | awk '{print $1 ":" $4 ":" $5}'` 'enable'
 
-[ "$CMD" = "+elected-leader" ] && \
+[ "$CMD" = "-odown" ] && [ "$ARG1" = "master" ] && \
 	call_curl `echo $ARGS | awk '{print $2 ":" $3 ":" $4}'` 'enable'
 
 # without exit code, sentinel thinks the script is still running and locks any further execution

--- a/notification.sh
+++ b/notification.sh
@@ -9,6 +9,7 @@ call_curl () {
 	DATA=`echo "s=$1&action=$2&b=%234" | sed -e s/:/%3A/`
 	curl --silent -o /dev/null $HAPROXY --data "$DATA"
 	echo curl $HAPROXY --data "$DATA"
+	return 0
 }
 
 
@@ -19,7 +20,8 @@ call_curl () {
 	call_curl `echo $ARGS | awk '{print $6 ":" $3 ":" $4}'` 'disable'
 
 [ "$CMD" = "+switch-master" ] && \
-	call_curl `echo $ARGS | awk '{print $1 ":" $4 ":" $5}'` 'enable'
+	call_curl `echo $ARGS | awk '{print $1 ":" $4 ":" $5}'` 'enable' &&
+	call_curl `echo $ARGS | awk '{print $1 ":" $2 ":" $3}'` 'disable'
 
 [ "$CMD" = "-odown" ] && [ "$ARG1" = "master" ] && \
 	call_curl `echo $ARGS | awk '{print $2 ":" $3 ":" $4}'` 'enable'


### PR DESCRIPTION
Changes:
- on `-odown` event, we should re-enable master
- master should be disabled only on `+odown` event, not `+sdown`
- sentinel never invokes script for `convert-to-slave` event (better to remove an un-tested feature)
- disable old master when switching master (when failover process started manually, we only receive switch-master event)
- redirect curl output to /dev/null (it apperas in sentinel logs, and only contains whitespaces and newlines)
